### PR TITLE
Make autoprogram work with Sphinx 1.7

### DIFF
--- a/sphinxcontrib/autoprogram.py
+++ b/sphinxcontrib/autoprogram.py
@@ -25,9 +25,15 @@ from docutils import nodes
 from docutils.parsers.rst.directives import unchanged
 from docutils.statemachine import StringList, ViewList
 from six import exec_
-from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
 from sphinx.domains import std
+
+try:
+    # sphinx.util.compat.Directive class is now deprecated.
+    # Please use instead docutils.parsers.rst.Directive
+    from sphinx.util.compat import Directive
+except ImportError:
+    from docutils.parsers.rst import Directive
 
 __all__ = ('AutoprogramDirective',
            'AutoprogramDirectiveTestCase', 'ScannerTestCase',


### PR DESCRIPTION
`sphinx.util.compat` was removed from Sphinx 1.7

Fixes #1 and Gallopsled/pwntools#1113