### PR TITLE
New :groups: option to render argument groups

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,8 @@ Version 0.1.5
 
 To be released.
 
+- New ``:groups:`` option to render argument groups. [by Lukas Atkinson]
+
 
 Version 0.1.4
 -------------

--- a/doc/cli_with_groups.py
+++ b/doc/cli_with_groups.py
@@ -1,0 +1,18 @@
+import argparse
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('integers', metavar='N', type=int, nargs='+',
+                    help='An integer for the accumulator.')
+
+calculator_opts = parser.add_argument_group('Calculator Options')
+calculator_opts.add_argument(
+    '-i', '--identity', type=int, default=0,
+    help='the default result for no arguments ' '(default: 0)')
+calculator_opts.add_argument(
+    '--sum', dest='accumulate', action='store_const',
+    const=sum, default=max,
+    help='Sum the integers (default: find the max).')
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    print(args.accumulate(args.integers))

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -62,7 +62,7 @@ That's it.  It will be rendered as:
        :prog: cli.py
 
 If there are subcommands (subparsers), they are rendered to subsections.
-For example, givem the following Python CLI program (say it's
+For example, given the following Python CLI program (say it's
 :file:`subcmds.py`):
 
 .. include:: subcmds.py
@@ -77,6 +77,25 @@ The above reStructuredText will render:
 
     .. autoprogram:: subcmds:parser
        :prog: subcmds.py
+
+If there are argument groups, they can optionally be rendered as subsections,
+just like subcommands.
+For example:
+
+.. include:: cli_with_groups.py
+    :code:
+
+.. code-block:: rst
+
+    .. autoprogram:: cli_with_groups:parser
+        :prog: cli_with_groups.py
+        :groups:
+
+The above reStructuredText Text will render:
+
+    .. autoprogram:: cli_with_groups:parser
+        :prog: cli_with_groups.py
+        :groups:
 
 .. rst:directive:: .. autoprogram:: module:parser
 
@@ -110,6 +129,9 @@ Additional Options for :rst:dir:`.. autoprogram::`
 
 .. versionadded:: 0.1.3
 
+``:groups:``
+    Render argument groups as subsections.
+
 ``:maxdepth: ##``
     Only show subcommands to a depth of ``##``.
 
@@ -119,7 +141,7 @@ Additional Options for :rst:dir:`.. autoprogram::`
 ``:start_command: subcommand``
     Render document for the given subcommand. ``subcommand`` can be a space
     separated list to render a sub-sub-...-command. 
-    
+
 ``:strip_usage:``
     Removes all but the last word in the usage string before the first option,
     replaces it with '...', and removes an amount of whitespace to realign

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -127,25 +127,33 @@ The above reStructuredText Text will render:
 Additional Options for :rst:dir:`.. autoprogram::`
 --------------------------------------------------
 
-.. versionadded:: 0.1.3
-
 ``:groups:``
     Render argument groups as subsections.
+
+    .. versionadded:: 0.1.5
 
 ``:maxdepth: ##``
     Only show subcommands to a depth of ``##``.
 
+    .. versionadded:: 0.1.3
+
 ``:no_usage_codeblock:``
     Don't put the usage text in a :rst:dir:`.. codeblock:: console` directive.
+
+    .. versionadded:: 0.1.3
 
 ``:start_command: subcommand``
     Render document for the given subcommand. ``subcommand`` can be a space
     separated list to render a sub-sub-...-command. 
 
+    .. versionadded:: 0.1.3
+
 ``:strip_usage:``
     Removes all but the last word in the usage string before the first option,
     replaces it with '...', and removes an amount of whitespace to realign
     subsequent lines.
+
+    .. versionadded:: 0.1.3
 
 
 Author and license


### PR DESCRIPTION
Currently, all arguments are are shown in a single list. This PR implements a `:group:` option which displays argument groups similar to subcommands. This gets the output closer to the default argparse `--help` formatting. The motivation for this was gcovr/gcovr#252.

Example screenshot (from the updated docs):

![Screenshot of argument groups](https://user-images.githubusercontent.com/1782927/38832687-9adb2020-41c3-11e8-8d13-3d11814e2f84.png)

As currently implemented, there is no nesting: groups in groups, groups in subcommands, or subcommands in groups have not been tested. Empty groups are skipped, because the two default groups (positional and optional arguments) may or may not be used.

To simplify this change, the first two commits do some refactoring:

 - option formatting is extracted into separate functions, which would otherwise be duplicated
 - a `render_rst()` function was extracted from the `AutoprogramDirective.make_rst()` function, so that there's a clearer separation between presentational details and argparse logic.

The code is tested through the example in the docs, and the `scan_programs()` enhancement is tested through a new unit test. This unit tests also covers empty group exclusion. This seems to work, although the py33-sphinx17 tests consistently failed in my Travis build.