### PR TITLE
Added new option `label` in `autoprogram` directive.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,8 @@ Version 0.1.6
 
 To be released.
 
+- New option ``label`` to add a label/anchor that can be referenced with ``:ref:``.
+
 
 Version 0.1.5
 -------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -132,6 +132,16 @@ Additional Options for :rst:dir:`.. autoprogram::`
 
     .. versionadded:: 0.1.5
 
+
+``:label: prefix``
+    Adds a label/anchor that can be referenced with ``:ref:``.
+
+    If the parser has multiple subcommands, each subcommand generates one
+    reference. Each subcommand reference is created as a concatenation from
+		``prefix`` and ``subcommand``.
+
+    .. versionadded:: 0.1.6
+
 ``:maxdepth: ##``
     Only show subcommands to a depth of ``##``.
 

--- a/sphinxcontrib/autoprogram.py
+++ b/sphinxcontrib/autoprogram.py
@@ -160,6 +160,7 @@ class AutoprogramDirective(Directive):
         'strip_usage': unchanged,
         'no_usage_codeblock': unchanged,
         'groups': unchanged,
+        'label': unchanged,
     }
 
     def make_rst(self):
@@ -257,6 +258,11 @@ def render_rst(title, options, is_program, is_subgroup, description,
     if is_program:
         yield '.. program:: ' + title
         yield ''
+
+    if 'label' in options:
+        label = (options.get('label') + title).replace(" ", "-")
+        yield ".. _{label}:".format(label=label)
+        yield ""
 
     yield title
     yield ('!' if is_subgroup else '?') * len(title)


### PR DESCRIPTION
This adds an optional label (anchor) to each auto documented program.

**Usage:**

```rest
.. autoprogram::
   :label: <myLabel>
```

**Inserted reST:**

```rest
.. _<myLabel>:<title>:
```

The label can be referenced with :ref:`labelName` in reST.

Solves #6.

-----------------------
/cc @eine 