### PR TITLE
Reraise the original exception

### DIFF
--- a/sphinxcontrib/autoprogram.py
+++ b/sphinxcontrib/autoprogram.py
@@ -140,7 +140,7 @@ def import_object(import_name):
                 mod = __import__("foo")
                 break
         else:
-            raise ImportError("No module named {}".format(module_name))
+            raise
 
     mod = reduce(getattr, module_name.split('.')[1:], mod)
     globals_ = builtins


### PR DESCRIPTION
In case the ImportError comes from something inside, this makes it way easier to debug code with failing imports.