### PR TITLE
Protect against indented multi-line descriptions

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,6 +11,8 @@ To be released.
 - Test against recent versions of Sphinx [:issue:`33`, :pull:`32` by Langston Barrett]
 - Format source code with Black [:issue:`30`, :pull:`32` by Langston Barrett]
 - Add documentation to the ``sdist`` [:issue:`26`, :pull:`32` by Langston Barrett]
+- Fixed unwanted ``<blockquote>`` tags in multi-line command descriptions that
+  are indented to match surrounding code. [:pull:`21` by dgw]
 
 
 Version 0.1.5

--- a/sphinxcontrib/autoprogram.py
+++ b/sphinxcontrib/autoprogram.py
@@ -11,6 +11,7 @@
 # pylint: disable=protected-access,missing-docstring
 import argparse
 import collections
+import inspect
 import os
 import re
 import sys
@@ -280,7 +281,7 @@ def render_rst(
     yield ("!" if is_subgroup else "?") * len(title)
     yield ""
 
-    for line in (description or "").splitlines():
+    for line in inspect.cleandoc(description or "").splitlines():
         yield line
     yield ""
 


### PR DESCRIPTION
Sphinx will happily e.g. turn the following into a `<blockquote>` when outputting HTML, because the leading indentation makes it look like one.

```python
    list_parser = subparsers.add_parser(
        'list',
        help="List available configurations from config directory",
        description="""
            List available configurations from config directory with the
            extension ".cfg". Use option ``--config-dir`` to use a
            specific config directory.
        """)
```

Python's `inspect.cleandoc()` function was meant to handle this case, making sure that any excess indentation is stripped away.

@Exirel, this will fix the documentation rendering issue I pinged you about on IRC earlier.