### PR TITLE
README: Fix typo (arparser -> argparse)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
    :target: https://travis-ci.org/sphinx-contrib/autoprogram
 
 This contrib extension, ``sphinxcontrib.autoprogram``, provides an automated
-way to document CLI programs.  It scans ``arparser.ArgumentParser`` object,
+way to document CLI programs.  It scans ``argparse.ArgumentParser`` object,
 and then expands it into a set of ``.. program::`` and ``.. option::``
 directives.
 


### PR DESCRIPTION
Fix the typo pointed out in #13 