### PR TITLE
Lint with Mypy, Pylint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info/
+mypy_cache/
 *.pyc
 .*.swp
 .cache/

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,55 @@
+[MASTER]
+
+ignore=.git
+jobs=0
+suggestion-mode=yes
+
+[MESSAGES CONTROL]
+
+disable=all
+enable=assign-to-new-keyword,
+       bad-format-character,
+       bad-format-string-key,
+       bad-open-mode,
+       bad-string-format-type,
+       consider-using-get,
+       consider-using-join,
+       empty-docstring,
+       function-redefined,
+       not-in-loop,
+       redefined-builtin,
+       return-in-init,
+       too-few-format-args,
+       too-many-format-args,
+       truncated-format-string,
+       unnecessary-comprehension,
+       unused-argument,
+       unreachable,
+       unused-format-string-argument,
+       unused-format-string-key,
+       unused-import,
+       unused-variable,
+       using-constant-test
+
+[REPORTS]
+
+output-format=text
+reports=no
+score=no
+
+[BASIC]
+
+argument-naming-style=snake_case
+attr-naming-style=snake_case
+class-naming-style=PascalCase
+const-naming-style=UPPER_CASE
+function-naming-style=snake_case
+include-naming-hint=yes
+inlinevar-naming-style=snake_case
+method-naming-style=snake_case
+module-naming-style=snake_case
+variable-naming-style=snake_case
+
+[VARIABLES]
+
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+# TODO: Enable these
+# disallow_any_generics = True
+# disallow_incomplete_defs = True
+# disallow_untyped_defs = True
+show_error_codes = True
+ignore_missing_imports = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@
 [tox]
 envlist =
     {py37,py38,py39}-{sphinx34,sphinx33,sphinx32,sphinx24,sphinx18}
-    {py27,pypy}-{sphinx18}
-    black
-    flake8
+    black flake8 mypy pylint
 minversion = 2.7.0
 
 [testenv]
@@ -48,3 +46,15 @@ deps =
     black
 commands =
     black --check --diff sphinxcontrib
+
+[testenv:mypy]
+deps =
+    mypy
+commands =
+    mypy sphinxcontrib
+
+[testenv:pylint]
+deps =
+    pylint
+commands =
+    pylint sphinxcontrib


### PR DESCRIPTION
Drops Pypy support, as Pypy doesn't allow type annotations.

Fixes #31 