### PR TITLE
Require future-annotations on Python <3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,11 @@ from setuptools import setup, find_packages
 # Do not change the variable name.  It's parsed by doc/conf.py script.
 version = '0.1.7'
 
-requires = ['Sphinx >= 1.2', 'six']
+requires = [
+    'future-annotations;python_version<"3.7"',
+    'Sphinx >= 1.2',
+    'six'
+]
 
 
 def readme():

--- a/sphinxcontrib/autoprogram.py
+++ b/sphinxcontrib/autoprogram.py
@@ -1,3 +1,4 @@
+# -*- coding: future_annotations -*-
 """
     sphinxcontrib.autoprogram
     ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -8,8 +9,6 @@
     :license: BSD, see LICENSE for details.
 
 """
-from __future__ import annotations
-
 # pylint: disable=protected-access,missing-docstring
 import argparse
 import collections


### PR DESCRIPTION
In order to use `from __future__ import annotations` on Python 3.6 we need to install the future-annotations package.

Fix #42