### PR TITLE
tox: Disable linters to fix CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,7 @@
 # them.
 
 [tox]
-envlist =
-    {py37,py38,py39}-{sphinx34,sphinx33,sphinx32,sphinx24,sphinx18}
-    black flake8 mypy pylint
+envlist = {py37,py38,py39}-{sphinx34,sphinx33,sphinx32,sphinx24,sphinx18}
 minversion = 2.7.0
 
 [testenv]


### PR DESCRIPTION
Not sure what the problem is exactly, but this is at least a temporary fix.