### PR TITLE
ci: build the doc correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         pip install -r doc/rtd-requires.txt
         cd doc
-        make
+        make html
       working-directory: ${{ github.workspace }}/tmp/sdist
 
     - name: Install wheel


### PR DESCRIPTION
The current make command just shows the help, to really build the documenation we need to pass a parameter. This patch does the html build.