### PR TITLE
remove dependency on 'six' transitional library

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -52,4 +52,4 @@ variable-naming-style=snake_case
 
 [VARIABLES]
 
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+redefining-builtins-modules=builtins,io

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 # Do not change the variable name.  It's parsed by doc/conf.py script.
 version = '0.1.8'
 
-requires = ['Sphinx >= 1.2', 'six']
+requires = ['Sphinx >= 1.2']
 
 
 def readme():

--- a/sphinxcontrib/autoprogram.py
+++ b/sphinxcontrib/autoprogram.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 
 # pylint: disable=protected-access,missing-docstring
 import argparse
+import builtins
 import collections
 import inspect
 import os
 import re
 import sys
+from functools import reduce
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 import unittest
 from unittest import mock
@@ -25,8 +27,6 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import unchanged
 from docutils.statemachine import StringList, ViewList
-from six import exec_
-from six.moves import builtins, reduce
 from sphinx.domains import std
 from sphinx.util.nodes import nested_parse_with_titles
 
@@ -154,7 +154,7 @@ def import_object(import_name: str):
                 with open(f[0]) as fobj:
                     codestring = fobj.read()
                 foo = imp.new_module("foo")
-                exec_(codestring, foo.__dict__)
+                exec(codestring, foo.__dict__)
 
                 sys.modules["foo"] = foo
                 mod = __import__("foo")


### PR DESCRIPTION
Hi,

By adding annotations your project is certainly not compatible with Python2 anymore.

Please accept this PR to remove old remain of python2+3 compatibility

https://wiki.debian.org/Python3-six-removal