### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox
+        python -m pip install setuptools tox
 
     # NOTE(lb): By creating a sdist and then testing/working with that, we ensure
     # its completeness.
@@ -69,7 +69,7 @@ jobs:
       working-directory: ${{ github.workspace }}/tmp/sdist
 
     - name: Publish package
-      if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags') && matrix.python-version == 3.11
+      if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags') && matrix.python-version == 3.12
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -48,7 +47,7 @@ setup(
         'Topic :: Software Development :: Documentation',
         'Topic :: Utilities'
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     platforms='any',
     packages=find_packages(),
     namespace_packages=['sphinxcontrib'],

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: Stackless',
         'Topic :: Documentation',

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # them.
 
 [tox]
-envlist = {py37,py38,py39,py310,py311,py312}-{sphinx34,sphinx33,sphinx32,sphinx24,sphinx18}
+envlist = {py38,py39,py310,py311,py312}-{sphinx34,sphinx33,sphinx32,sphinx24,sphinx18}
 minversion = 2.7.0
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # them.
 
 [tox]
-envlist = {py37,py38,py39,py310,py311}-{sphinx34,sphinx33,sphinx32,sphinx24,sphinx18}
+envlist = {py37,py38,py39,py310,py311,py312}-{sphinx34,sphinx33,sphinx32,sphinx24,sphinx18}
 minversion = 2.7.0
 
 [testenv]


### PR DESCRIPTION
Fixes #70 

Open questions to owner of the repo:
- GitHub action: make versino 3.10 to 3.12 mandatory for PR to be build? (currently only 3.7 to 3.9 are required)
- Do you want to drop support for 3.7 as it is not supported anymore?